### PR TITLE
修复了MBIN偏移表8个00的情况和SNT以"为开头的文本块导出文本时的问题，修改导出格式以支持文本导入。

### DIFF
--- a/src/main_Exporter_MBIN.cpp
+++ b/src/main_Exporter_MBIN.cpp
@@ -60,6 +60,8 @@ int main(int argc, char* argv[])
 		for (int i = 0; i < num; i++) {
 			int type = GET_INT(buff + 4 + i * 8);
 			int offset = GET_INT(buff + 4 + i * 8 + 4);
+			int type_next;
+			while (i < num - 1 && (type_next = GET_INT(buff + 4 + i * 8 + 8)) == 0) i++;
 			int offset_next = i == num - 1 ? len - base: GET_INT(buff + 4 + i * 8 + 12);
 
 			int start = offset + base;
@@ -78,14 +80,28 @@ int main(int argc, char* argv[])
 					j = t;
 					cnt++; 
 					string text;
-					while (j < end) {
-						if (j < end - 1 && buff[j] == 2 && (buff[j + 1] == 3 || buff[j + 1] == 0)) break;
+					/*while (j < end) {
+					if (j < end - 1 && buff[j] == 2 && (buff[j + 1] == 3 || buff[j + 1] == 0)) break;
 
-						if (buff[j] == 1) text.append("\\n");
+					if (buff[j] == 1) text.append("\\n");
+					else if (buff[j] >= 0x20 && buff[j] < 0xFF) text.push_back(buff[j]);
+					j++;
+					}*/
+					while (j < end) {
+						if (j < end - 1 && buff[j] == 2 && (buff[j + 1] == 3 || buff[j + 1] == 0)) {
+							if (buff[j + 1] == 3) {
+								text.append("\\2\\3");
+							}
+							else if (buff[j + 1] == 0) {
+								text.append("\\2");
+							}
+							break;
+						}
+						if (j < end - 1 && buff[j] == 2 && (buff[j + 1] == 3 || buff[j + 1] == 0)) break;
+						if (buff[j] == 1) text.append("\\1\\n");
 						else if(buff[j] >= 0x20 && buff[j] < 0xFF) text.push_back(buff[j]);
 						j++;
 					}
-
 					if (out_cnt == 0) {
 						ofs.open(dir_out + name + ATTR_OUT);
 					}

--- a/src/main_Exporter_SNT.cpp
+++ b/src/main_Exporter_SNT.cpp
@@ -69,16 +69,17 @@ int main(int argc, char* argv[])
 			line_cnt++;
 			string line = buff_snt;
 			
-			if (line.find(STR_SAY) == 0) {
+			char ch = line[0];
+			if (line.find(STR_SAY) == 0 || (ch == '\"' &&  line.find(STR_SAY) == 1)) {
 				flag = FLAG_SAY;
 			}
-			else if (line.find(STR_TEXT) == 0) {
+			else if (line.find(STR_TEXT) == 0 || (ch == '\"' &&  line.find(STR_TEXT) == 1)) {
 				flag = FLAG_TEXT;
 			}
-			else if (line.find(STR_TALK) == 0) {
+			else if (line.find(STR_TALK) == 0 || (ch == '\"' &&  line.find(STR_TALK) == 1)) {
 				flag = FLAG_TALK;
 			}
-			else if (line.find(STR_MENU) == 0) {
+			else if (line.find(STR_MENU) == 0 || (ch == '\"' &&  line.find(STR_MENU) == 1)) {
 				flag = FLAG_MENU;
 			}
 			else if(line.find(STR_4TBL) == 0 && (FLAG_SAY == flag || FLAG_TEXT == flag || FLAG_TALK == flag)) {
@@ -87,7 +88,7 @@ int main(int argc, char* argv[])
 				}
 				text += line.c_str() + 4;
 
-				if (text.length() >= 2 && text[text.length() - 2] == '\\' && text[text.length() - 1] == '3') {
+				/*if (text.length() >= 2 && text[text.length() - 2] == '\\' && text[text.length() - 1] == '3') {
 					text.pop_back();
 					text.pop_back();
 				}
@@ -106,6 +107,19 @@ int main(int argc, char* argv[])
 				}
 				else if (text.length() >= 2 && text[text.length() - 2] == '\\' && text[text.length() - 1] == '1') {
 					text.back() = 'n';
+				}*/
+				//if ((text.length() >= 2 && text[text.length() - 2] == '\\' && text[text.length() - 1] == '2') || (text.length() >= 4 && text[text.length() - 4] == '\\' && text[text.length() - 3] == '2')) {
+				if (text.find("\\2") != string::npos) {
+					if (out_cnt == 0) {
+						ofs.open(dir_out + name + ATTR_OUT);
+					}
+					ofs << setfill('0') << setw(6) << setiosflags(ios::right) << line_no << ","
+						<< text << "\n\n";
+					++out_cnt;
+					text.clear();
+				}
+				else {
+					text.append("\\n");
 				}
 			}
 			else if (line.find(CH_SQ) == 0 && FLAG_TALK == flag) {


### PR DESCRIPTION
==================================================================
（1）SNT和MBIN的导出文本内容格式修改：保留\1\2\3，并且加入\n作为同一句多行内的断行标记，以支持之后SNT文本修改后的导入，并让MBIN和SNT的导出文本格式相匹配。
（2）修改了MBIN从偏移表获取每句文本的起始地址和结束地址的代码，以支持中文版MBIN中出现的无意义的8个00偏移表项。
（3）修改了从SNT导出文本时，部分文本区块以"为开头导致遗漏的情况。
（4）修改了从SNT导出文本时，\2\3不在行末而没有正确进行断行的情况。